### PR TITLE
ESP32 Support for VSPI and HSPI

### DIFF
--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -50,9 +50,24 @@ bool MCP23S17::begin()
 
   if (_hwSPI)
   {
-    //  _mySPI = &SPI;  //  set in constructor  #10
+    #if defined(ESP32)
+    if (_useHSPI)      //  HSPI
+    {
+      _mySPI = new SPIClass(HSPI);
+      _mySPI->end();
+      _mySPI->begin(14, 12, 13, _select);   //  CLK=14  MISO=12  MOSI=13
+    }
+    else               //  VSPI
+    {
+      _mySPI = new SPIClass(VSPI);
+      _mySPI->end();
+      _mySPI->begin(18, 19, 23, _select);   //  CLK=18  MISO=19  MOSI=23
+    }
+    #else              //  generic hardware SPI
+    _mySPI = &SPI;
     _mySPI->end();
     _mySPI->begin();
+    #endif
   }
   else
   {

--- a/MCP23S17.h
+++ b/MCP23S17.h
@@ -92,6 +92,17 @@ public:
   void     enableControlRegister(uint8_t mask);
   void     disableControlRegister(uint8_t mask);
 
+  //  ESP32 specific
+  #if defined(ESP32)
+  void     selectHSPI() { _useHSPI = true;  };
+  void     selectVSPI() { _useHSPI = false; };
+  bool     usesHSPI()   { return _useHSPI;  };
+  bool     usesVSPI()   { return !_useHSPI; };
+
+  //  to overrule ESP32 default hardware pins
+  void     setGPIOpins(uint8_t clk, uint8_t miso, uint8_t mosi, uint8_t select);
+  #endif
+
 
 private:
   //       access to low level registers (just make these two functions public).
@@ -115,6 +126,10 @@ private:
   SPISettings _spi_settings;
 
   uint8_t  swSPI_transfer(uint8_t val);
+
+  #if defined(ESP32)
+  bool        _useHSPI = true;
+  #endif
 };
 
 

--- a/examples/MCP23S17_performance/performance_0.2.4.md
+++ b/examples/MCP23S17_performance/performance_0.2.4.md
@@ -1,0 +1,25 @@
+
+
+# Performance test  
+
+Test sketch  MCP23S17_performance.ino
+
+Max clock frequency 10 MHz, ESP32 WROVER Module
+
+### Library version: 0.2.4
+
+|  Action                       |  SW SPI | HW 1 MHz | HW 2 MHz | HW 4 MHz | HW 8 MHz | HW 10 MHz | notes     |
+|:------------------------------|--------:|---------:|---------:|---------:|---------:|:---------:|:---------:|
+| TEST digitalWrite(0, value)   |  48.560 |   85.12  |  57.00   |  43.69   |  36.81   |  35.38   |
+| TEST digitalWrite(pin, value) |  47.750 |   84.50  |  41.94   |  42.69   |  26.62   |  25.62   |
+| TEST digitalRead(pin)         |  31.940 |   43.75  |  29.31   |  22.37   |  18.75   |  18.06   |
+|                               |         |          |          |          |          |          |
+| TEST write8(port, mask)       |  34.000 |   45.00  |  30.50   |  23.50   |  20.00   |  19.50   |
+| TEST read8(port)              |  34.500 |   46.00  |  31.50   |  24.50   |  21.00   |  20.50   |
+| TEST write16(mask)            |  32.500 |   44.00  |  29.50   |  22.50   |  19.00   |  18.00   | since 0.1.1
+| TEST read16()                 |  33.000 |   43.50  |  29.00   |  22.00   |  19.00   |  18.50   | since 0.1.1
+
+### Notes
+
+For this test I used the ESP32 WROVER Module (ESP32-WROVER-IE-N16R8), ESP32-DEVKITS-R and MCP23S17T-E/ML (28QFN)
+Software SPI : D2, D4 and D5


### PR DESCRIPTION
I started using this library in a personal project and I realised that the ESP32 SPI part is missing.

After checking the other library (MCP_ADC) I was able to use the same code style and format.