### PR TITLE
Implement sequential read/write for 16-bit operations

### DIFF
--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -71,11 +71,11 @@ bool MCP23S17::begin(bool pullup)
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.
   //  if (! writeReg(MCP23017_IOCR, MCP23017_IOCR_SEQOP)) return false;
-  uint8_t reg = readReg(MCP23017_IOCR);
-  if (reg & MCP23017_IOCR_SEQOP)  //  check if already zero
+  uint8_t reg = readReg(MCP23x17_IOCR);
+  if (reg & MCP23x17_IOCR_SEQOP)  //  check if already zero
   {
-    reg &= ~MCP23017_IOCR_SEQOP;  //  clear SEQOP bit for sequential read/write
-    if (! writeReg(MCP23017_IOCR, reg)) return false;
+    reg &= ~MCP23x17_IOCR_SEQOP;  //  clear SEQOP bit for sequential read/write
+    if (! writeReg(MCP23x17_IOCR, reg)) return false;
   }
 
   if (pullup)

--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -70,7 +70,6 @@ bool MCP23S17::begin(bool pullup)
   //    SEQOP: Sequential Operation mode bit
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.
-  //  if (! writeReg(MCP23017_IOCR, MCP23017_IOCR_SEQOP)) return false;
   uint8_t reg = readReg(MCP23x17_IOCR);
   if (reg & MCP23x17_IOCR_SEQOP)  //  check if already zero
   {

--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -66,6 +66,7 @@ bool MCP23S17::begin(bool pullup)
   if (! isConnected()) return false;
 
   //  disable address increment - datasheet P20
+  //  readReg16() and writeReg16() will not work with address increment disabled.
   //    SEQOP: Sequential Operation mode bit
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.
@@ -833,11 +834,6 @@ bool MCP23S17::writeReg16(uint8_t reg, uint16_t value)
     _mySPI->transfer(MCP23S17_WRITE_REG | _address );
     _mySPI->transfer(reg);
     _mySPI->transfer(value >> 8);
-    ::digitalWrite(_select, HIGH);
-
-    ::digitalWrite(_select, LOW);
-    _mySPI->transfer(MCP23S17_WRITE_REG | _address );
-    _mySPI->transfer(reg + 1);
     _mySPI->transfer(value & 0xFF);
     _mySPI->endTransaction();
   }
@@ -847,11 +843,6 @@ bool MCP23S17::writeReg16(uint8_t reg, uint16_t value)
     swSPI_transfer(MCP23S17_WRITE_REG | _address );
     swSPI_transfer(reg);
     swSPI_transfer(value >> 8);
-    ::digitalWrite(_select, HIGH);
-
-    ::digitalWrite(_select, LOW);
-    swSPI_transfer(MCP23S17_WRITE_REG | _address );
-    swSPI_transfer(reg + 1);
     swSPI_transfer(value & 0xFF);
   }
   ::digitalWrite(_select, HIGH);
@@ -880,11 +871,6 @@ uint16_t MCP23S17::readReg16(uint8_t reg)
     _mySPI->transfer(MCP23S17_READ_REG | _address );
     _mySPI->transfer(reg);
     rv = _mySPI->transfer(0xFF) << 8;
-    ::digitalWrite(_select, HIGH);
-
-    ::digitalWrite(_select, LOW);
-    _mySPI->transfer(MCP23S17_READ_REG | _address );
-    _mySPI->transfer(reg + 1);
     rv += _mySPI->transfer(0xFF);
     _mySPI->endTransaction();
   }
@@ -894,11 +880,6 @@ uint16_t MCP23S17::readReg16(uint8_t reg)
     swSPI_transfer(MCP23S17_READ_REG | _address );
     swSPI_transfer(reg);
     rv = swSPI_transfer(0xFF) << 8;
-    ::digitalWrite(_select, HIGH);
-
-    ::digitalWrite(_select, LOW);
-    swSPI_transfer(MCP23S17_READ_REG | _address );
-    swSPI_transfer(reg + 1);
     rv += swSPI_transfer(0xFF);
   }
   ::digitalWrite(_select, HIGH);

--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -66,7 +66,7 @@ bool MCP23S17::begin(bool pullup)
   if (! isConnected()) return false;
 
   //  disable address increment - datasheet P20
-  //  note that readReg16() and writeReg16() will not work with address increment disabled.
+  //  note that address increment must be enabled for readReg16() and writeReg16() to work.
   //    SEQOP: Sequential Operation mode bit
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.

--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -66,7 +66,7 @@ bool MCP23S17::begin(bool pullup)
   if (! isConnected()) return false;
 
   //  disable address increment - datasheet P20
-  //  readReg16() and writeReg16() will not work with address increment disabled.
+  //  note that readReg16() and writeReg16() will not work with address increment disabled.
   //    SEQOP: Sequential Operation mode bit
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.

--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -71,6 +71,12 @@ bool MCP23S17::begin(bool pullup)
   //    1 = Sequential operation disabled, address pointer does not increment.
   //    0 = Sequential operation enabled, address pointer increments.
   //  if (! writeReg(MCP23017_IOCR, MCP23017_IOCR_SEQOP)) return false;
+  uint8_t reg = readReg(MCP23017_IOCR);
+  if (reg & MCP23017_IOCR_SEQOP)  //  check if already zero
+  {
+    reg &= ~MCP23017_IOCR_SEQOP;  //  clear SEQOP bit for sequential read/write
+    if (! writeReg(MCP23017_IOCR, reg)) return false;
+  }
 
   if (pullup)
   {


### PR DESCRIPTION
Hi, this PR is implementing sequential read/write for 16-bit operations as described in the data sheet 3.2.1 page 13.
See test data below from running the MCP23S17_performance.ino sketch on an ESP32-S3@240mhz.

```
HW_SPI@8mhz before:
	TEST write16(mask): 13.50
	TEST read16(): 13.50

HW_SPI@8mhz with sequential read/write:
	TEST write16(mask): 10.50
	TEST read16(): 10.50

SW_SPI before:
	TEST write16(mask): 29.50
	TEST read16(): 29.50

SW_SPI with sequential read/write:
	TEST write16(mask): 20.00
	TEST read16(): 20.00
```