### PR TITLE
Bring enableInterrupt()/disableInterrupt() in line with other single pin interfaces

### DIFF
--- a/MCP23S17.cpp
+++ b/MCP23S17.cpp
@@ -637,7 +637,7 @@ bool MCP23S17::enableInterrupt(uint8_t pin, uint8_t mode)
 	gpinten |= mask;
 	if (pre_gpinten != gpinten)
 	{
-		return writeReg(GPINTENREG, value);
+		return writeReg(GPINTENREG, gpinten);
 	}
 	else
 	{
@@ -672,7 +672,7 @@ bool MCP23S17::disableInterrupt(uint8_t pin)
 	gpinten &= ~mask;
 	if (pre_gpinten != gpinten)
 	{
-		return writeReg(GPINTENREG, value);
+		return writeReg(GPINTENREG, gpinten);
 	}
 	else
 	{


### PR DESCRIPTION
Resolves #47

I tried to keep the spirit of the code as seen in the pinMode1 function. Also happened to hit some of the enhancements noted in the comments before the enableInterrupt function.

I don't have a very comprehensive testing setup but I did utilize the changes on the own board to set up interrupts and it behaved correctly.
